### PR TITLE
Add support for Bitwarden EU server (vault.bitwarden.eu)

### DIFF
--- a/BitwardenConstants.cs
+++ b/BitwardenConstants.cs
@@ -1,4 +1,10 @@
 public static class BitwardenConstants
 {
     public const string DEFAULT_SERVER_URL = "https://vault.bitwarden.com";
+    public const string EU_SERVER_URL = "https://vault.bitwarden.eu";
+    
+    public static string GetOfficialServerUrl(string region)
+    {
+        return region?.ToLower() == "eu" ? EU_SERVER_URL : DEFAULT_SERVER_URL;
+    }
 }

--- a/BitwardenFlowSettingPanel.xaml
+++ b/BitwardenFlowSettingPanel.xaml
@@ -89,6 +89,17 @@
                     FontWeight="Bold" 
                     Margin="0,0,0,10"/>
             
+            <!-- Official Server Selection -->
+            <TextBlock Text="Official Bitwarden Server:" FontWeight="SemiBold" Margin="0,0,0,5"/>
+            <ComboBox x:Name="OfficialServerComboBox" 
+                    Width="200" 
+                    HorizontalAlignment="Left"
+                    Margin="0,0,0,15"
+                    SelectionChanged="OfficialServerComboBox_SelectionChanged">
+                <ComboBoxItem Content="bitwarden.com (US)" Tag="com"/>
+                <ComboBoxItem Content="bitwarden.eu (Europe)" Tag="eu"/>
+            </ComboBox>
+            
             <CheckBox x:Name="UseCustomServerCheckBox" 
                     Content="Use Self-Hosted Instance" 
                     Margin="0,0,0,10"

--- a/BitwardenFlowSettings.cs
+++ b/BitwardenFlowSettings.cs
@@ -17,6 +17,9 @@ namespace Flow.Launcher.Plugin.BitwardenSearch
         [JsonProperty("sessionKey")]
         public string SessionKey { get; set; } = string.Empty;
 
+        [JsonProperty("officialServerRegion")]
+        public string OfficialServerRegion { get; set; } = "com"; // "com" or "eu"
+
         [JsonProperty("useCustomServer")]
         public bool UseCustomServer { get; set; } = false;
 


### PR DESCRIPTION
## 🚀 Feature: EU Server Support

Resolves #22 

### 📝 Summary
This PR adds support for the Bitwarden EU server (`vault.bitwarden.eu`) while maintaining full backward compatibility with the existing US server functionality.

### 🎯 Changes Made

#### Settings Panel (`BitwardenFlowSettingPanel.xaml/.cs`)
- ✅ Added dropdown to select between official servers:
  - `bitwarden.com (US)` - Default option
  - `bitwarden.eu (Europe)` - New EU option
- ✅ Auto-disable official server selection when using custom server
- ✅ Clear credentials when switching servers
- ✅ Added server configuration status feedback

#### Core Logic (`BitwardenFlowSettings.cs`)
- ✅ Added `OfficialServerRegion` property (default: "com")
- ✅ Maintains existing custom server settings

#### Server Management (`BitwardenConstants.cs`, `BitwardenCliConfigManager.cs`)
- ✅ Added EU server constant and helper function
- ✅ Added `ConfigureOfficialServer()` method
- ✅ Removed unused `ResetToDefaultServer()` method
- ✅ Eliminated duplicate constants

#### Initialization (`Main.cs`)
- ✅ Added `ConfigureServerFromSettings()` to apply server on startup
- ✅ Automatic server configuration based on user settings

### 🔧 Technical Details
- **Backward Compatible**: US server remains the default
- **No Breaking Changes**: Existing users won't be affected
- **Clean Implementation**: Removed duplicate code and unused functions
- **Robust Error Handling**: Proper logging and error management

### ✅ Testing
- [x] Plugin builds successfully
- [x] Settings panel displays correctly
- [x] Server switching works as expected
- [x] Credentials are cleared when switching servers
- [x] Default behavior unchanged for existing users

### ⚠️ Important Notes
- **Self-Hosted Instances**: The existing "Use Self-Hosted Instance" functionality has not been thoroughly tested with these changes. While the code logic should preserve existing behavior, additional testing with self-hosted Bitwarden instances is recommended.

### 📸 Screenshots
<img width="1292" height="923" alt="Screenshot 2025-08-08 162739" src="https://github.com/user-attachments/assets/a2b60940-e5ec-49f6-98ad-a15fbb56d590" />

### 🌍 Impact
This change enables European users to use the plugin with their EU-based Bitwarden accounts while maintaining full compatibility for existing US server users.